### PR TITLE
Code cleanup and version parsing modification

### DIFF
--- a/easy_pil/__init__.py
+++ b/easy_pil/__init__.py
@@ -1,11 +1,7 @@
-from collections import namedtuple
 from .canvas import Canvas
 from .editor import Editor
 from .font import Font
 from .text import Text
 from .utils import run_in_executor, load_image, load_image_async
+from ._version import __version__, version_info
 
-__version__ = "0.1.1"
-VersionInfo = namedtuple("VersionInfo", "major minor macro release")
-
-version_info = VersionInfo(0, 1, 1, "stable")

--- a/easy_pil/_version.py
+++ b/easy_pil/_version.py
@@ -1,0 +1,8 @@
+from collections import namedtuple
+
+__version__ = "0.1.2"
+
+VersionInfo = namedtuple("VersionInfo", "major minor macro release")
+
+version_info = VersionInfo(*map(int, __version__.split('.')), "stable")
+

--- a/easy_pil/editor.py
+++ b/easy_pil/editor.py
@@ -13,13 +13,10 @@ class Editor:
     def __init__(self, image: Union[Image.Image, str, Editor, Canvas]) -> None:
         if type(image) == str:
             self.image = Image.open(image)
-
-        elif type(image) == Canvas or type(image) == Editor:
+        elif isinstance(image, Canvas) or isinstance(image, Editor):
             self.image = image.image
-
         else:
             self.image = image
-
         self.image = self.image.convert("RGBA")
 
     @property

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 Pillow>=8.3.1,<=8.4.1
 requests>=2.26.0
-typing-extensions==4.0.1
+typing-extensions>=4.0.1
 aiohttp>=3.6.0,<3.8.0

--- a/setup.py
+++ b/setup.py
@@ -1,27 +1,22 @@
-import re
-import pathlib
+from pathlib import Path
+from importlib.util import spec_from_file_location, module_from_spec
 from setuptools import setup, find_packages
 
-requirements = []
 with open("requirements.txt") as f:
     requirements = f.read().splitlines()
 
-long_description = (pathlib.Path(__file__).parent.resolve() / "README.md").read_text(
-    encoding="utf-8"
-)
+current_directory = Path(__file__).parent.resolve()
 
-version = ""
-with open("easy_pil/__init__.py") as f:
-    version = re.search(
-        r'^__version__\s*=\s*[\'"]([^\'"]*)[\'"]', f.read(), re.MULTILINE
-    ).group(1)
+long_description = (current_directory / "README.md").read_text(encoding="utf-8")
 
-if not version:
-    raise RuntimeError("version is not set")
+vpath = current_directory / 'easy_pil' / '_version.py'
+spec = spec_from_file_location(vpath.name.removesuffix('.py'), vpath)
+mod = module_from_spec(spec)
+spec.loader.exec_module(mod)
 
 setup(
     name="easy-pil",
-    version=version,
+    version=mod.__version__,
     description="A library to make common tasks of Pillow easy.",  # Optional
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
I've made a couple of changes based on our discussion of #3. The biggest one is to move the version info into a separate file, which maintains the version info in a self contained manner, and can be imported by both top level `__init__.py` and in `setup.py`. This is less error prone (in my opinion) than trying to parse python code with regex in `setup.py`.

I also added tags to my fork of the repo (https://github.com/madphysicist/easy-pil). I can't push the tags to you directly, but here are the commands I used to create them:

```
$ git tag -a v0.0.1 -m 'Version 0.0.1 Stable' 9dca57fa2ed1f6f29884f2b529859341d630f2a0
$ git tag -a v0.0.3 -m 'Version 0.0.3 Stable' 7c229810640d424f2fad0e837330bd8630d8b819
$ git tag -a v0.0.4 -m 'Version 0.0.4 Stable' b435c7996d0eadef355c000ab489369dcb48edf0
$ git tag -a v0.0.5 -m 'Version 0.0.5 Stable' ef226d13f4b4d8074f4545f9cb31b046431d9332
$ git tag -a v0.0.6 -m 'Version 0.0.6 Stable' 39af809d89906de4c5766a6698cd54c774903c16
$ git tag -a v0.0.7 -m 'Version 0.0.7 Stable' 69958d066725b2c0242e6c8e6a564f3e786a1469
$ git tag -a v0.0.8 -m 'Version 0.0.8 Stable' 6091930267e8bcb972ce21c3839d38bb7659b6e0
$ git tag -a v0.1.0 -m 'Version 0.1.0 Stable' cf259c0f9d370506d8d0bc2ef521f040467499a3
$ git tag -a v0.1.1 -m 'Version 0.1.1 Stable' 2624d3d5b2575438554f3ef5bdeb06d3781a05c4
$ git push --tags
```

I place the tag immediately before you change version numbers, so someone checking out the tag gets the latest and greatest stable code with that version number, and not the initial switchover. If you use feature/development branches, which you squash when merging to master, each commit in master will roughly correspond to a micro version increment.

Please let me know your thoughts. I'd be happy to change anything you don't like or would like to see added to this PR.