### PR TITLE
Add a stroke parameter to Editor.text

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Easy PIL
-A python library built on top of [PIL](https://github.com/python-pillow/Pillow) to easily edit/modify images. 
+A Python library built on top of [PIL](https://github.com/python-pillow/Pillow) to easily edit/modify images. 
 
 ## Getting Started
 Using this for the first time? Here are some links to help you get started.
 
-- Readt the [docs](https://easy-pil.readthedocs.io/en/latest/)
+- Read the [docs](https://easy-pil.readthedocs.io/en/latest/)
 - First steps [Introduction](https://easy-pil.readthedocs.io/en/latest/pages/intro.html)
 - Integrate in a [Discord bot](https://easy-pil.readthedocs.io/en/latest/pages/discordbot.html)
 - Some premade [Examples](https://github.com/shahriyardx/easy-pil/tree/master/examples)

--- a/easy_pil/editor.py
+++ b/easy_pil/editor.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from io import BytesIO
-from typing import List, Tuple, Union
+from typing import List, Optional, Tuple, Union
 
 from PIL import Image, ImageDraw, ImageFilter, ImageFont
 from typing_extensions import Literal
@@ -230,6 +230,7 @@ class Editor:
         font: Union[ImageFont.FreeTypeFont, Font] = None,
         color: Color = "black",
         align: Literal["left", "center", "right"] = "left",
+        stroke: Optional[Union[int, Tuple[int], Tuple[int, str]]] = None,
     ) -> Editor:
         """Draw text into image
 
@@ -245,6 +246,10 @@ class Editor:
             Color of the font, by default "black"
         align : Literal["left", "center", "right"], optional
             Align text, by default "left"
+        stroke : Union[int, Tuple[int], Tuple[int, str]], optional
+            Whether there should be any stroke. Defaults to
+            None. If only one parameter is passed, the
+            default color is black.
         """
         if isinstance(font, Font):
             font = font.font
@@ -252,7 +257,19 @@ class Editor:
         anchors = {"left": "lt", "center": "mt", "right": "rt"}
 
         draw = ImageDraw.Draw(self.image)
-        draw.text(position, text, color, font=font, anchor=anchors[align])
+
+        if stroke:
+            if isinstance(stroke, int):
+                draw.text(position, text, color, font=font, anchor=anchors[align],
+                          stroke_width=stroke, stroke_fill="black")
+            elif len(stroke) > 1:
+                draw.text(position, text, color, font=font, anchor=anchors[align],
+                          stroke_width=stroke[0], stroke_fill=stroke[1])
+            else:
+                draw.text(position, text, color, font=font, anchor=anchors[align],
+                          stroke_width=stroke[0], stroke_fill="black")
+        else:
+            draw.text(position, text, color, font=font, anchor=anchors[align])
 
         return self
 

--- a/easy_pil/editor.py
+++ b/easy_pil/editor.py
@@ -230,7 +230,7 @@ class Editor:
         font: Union[ImageFont.FreeTypeFont, Font] = None,
         color: Color = "black",
         align: Literal["left", "center", "right"] = "left",
-        stroke_width: Optional[int] = None,
+        stroke_width: int = None,
         stroke_fill: Color = "black"
     ) -> Editor:
         """Draw text into image

--- a/easy_pil/editor.py
+++ b/easy_pil/editor.py
@@ -230,7 +230,8 @@ class Editor:
         font: Union[ImageFont.FreeTypeFont, Font] = None,
         color: Color = "black",
         align: Literal["left", "center", "right"] = "left",
-        stroke: Optional[Union[int, Tuple[int], Tuple[int, str]]] = None,
+        stroke_width: Optional[int] = None,
+        stroke_fill: Color = "black"
     ) -> Editor:
         """Draw text into image
 
@@ -246,10 +247,12 @@ class Editor:
             Color of the font, by default "black"
         align : Literal["left", "center", "right"], optional
             Align text, by default "left"
-        stroke : Union[int, Tuple[int], Tuple[int, str]], optional
+        stroke_width : int, optional
             Whether there should be any stroke. Defaults to
-            None. If only one parameter is passed, the
-            default color is black.
+            None. It represents the width of the said stroke.
+        stroke_fill : Color, optional
+            Color of the stroke, if any stroke is applied to the
+            text. Defaults to "black"
         """
         if isinstance(font, Font):
             font = font.font
@@ -258,16 +261,9 @@ class Editor:
 
         draw = ImageDraw.Draw(self.image)
 
-        if stroke:
-            if isinstance(stroke, int):
-                draw.text(position, text, color, font=font, anchor=anchors[align],
-                          stroke_width=stroke, stroke_fill="black")
-            elif len(stroke) > 1:
-                draw.text(position, text, color, font=font, anchor=anchors[align],
-                          stroke_width=stroke[0], stroke_fill=stroke[1])
-            else:
-                draw.text(position, text, color, font=font, anchor=anchors[align],
-                          stroke_width=stroke[0], stroke_fill="black")
+        if stroke_width:
+            draw.text(position, text, color, font=font, anchor=anchors[align],
+                      stroke_width=stroke_width, stroke_fill=stroke_fill)
         else:
             draw.text(position, text, color, font=font, anchor=anchors[align])
 

--- a/examples/welcome_image2.py
+++ b/examples/welcome_image2.py
@@ -16,7 +16,7 @@ poppins_light = Font.poppins(size=20, variant="light")
 background.paste(profile, (325, 90))
 background.ellipse((325, 90), 150, 150, outline="gold", stroke_width=4)
 background.text(
-    (400, 260), "WELCOME", color="white", font=poppins, align="center"
+    (400, 260), "WELCOME", color="white", font=poppins, align="center", stroke=2
 )
 background.text(
     (400, 325),

--- a/examples/welcome_image2.py
+++ b/examples/welcome_image2.py
@@ -16,7 +16,7 @@ poppins_light = Font.poppins(size=20, variant="light")
 background.paste(profile, (325, 90))
 background.ellipse((325, 90), 150, 150, outline="gold", stroke_width=4)
 background.text(
-    (400, 260), "WELCOME", color="white", font=poppins, align="center", stroke=2
+    (400, 260), "WELCOME", color="white", font=poppins, align="center", stroke_width=2
 )
 background.text(
     (400, 325),


### PR DESCRIPTION
Here is an example by editing `welcome_image2.py`.

## Before

```python
background.text(
    (400, 260), "WELCOME", color="white", font=poppins, align="center"
)
```

![image](https://user-images.githubusercontent.com/32136919/235441231-608fa426-af33-494b-81df-2a98665fc44d.png)

## After

```python
background.text(
    (400, 260), "WELCOME", color="white", font=poppins, align="center", stroke=2
)
```

![image](https://user-images.githubusercontent.com/32136919/235441189-fb5262ee-3b6a-45a6-b25b-c5975f92c6a9.png)
