### PR TITLE
ci: rewrite lint-test workflow for uv + ruff + pytest

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -3,7 +3,7 @@ name: Lint & Test
 on:
   push:
     branches:
-      - 'master'
+      - "master"
   pull_request:
   merge_group:
     types: [checks_requested]
@@ -15,69 +15,50 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
-defaults:
-  run:
-    shell: bash
-
 jobs:
   lint:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+      - uses: actions/checkout@v4.2.2
 
-    - name: Run pre-commit
-      id: pre-commit
-      uses: pre-commit/action@v3.0.0
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
 
-  pyright:
+      - name: Set up Python
+        uses: actions/setup-python@v5.6.0
+        with:
+          python-version-file: ".python-version"
+
+      - name: Install dependencies
+        run: uv sync --only-group dev
+
+      - name: Ruff check
+        run: uv run ruff check .
+
+      - name: Ruff format
+        run: uv run ruff format --check .
+
+  test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
-        experimental: [false]
+        python-version: ["3.11", "3.12", "3.13"]
       fail-fast: false
-    continue-on-error: ${{ matrix.experimental }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4.2.2
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5.6.0
         with:
           python-version: ${{ matrix.python-version }}
+
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install flake8 pytest
-          python -m pip install .
-          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-      - name: Lint with flake8
-        run: |
-          flake8 ./easy_pil --count --select=E9,F63,F7,F82 --show-source --statistics
-          flake8 ./easy_pil --count --exit-zero --max-complexity=10 --max-line-length=79 --statistics
+        run: uv sync
+
       - name: Test with pytest
-        run: |
-          pytest
-
-
-      - name: Run pyright (Linux)
-        uses: jakebailey/pyright-action@v1.4.1
-        id: pyright-linux
-        with:
-          version: ${{ env.PYRIGHT_VERSION }}
-          python-version: ${{ steps.setup-env.outputs.python-version }}
-          python-platform: "Linux"
-          no-comments: ${{ matrix.python-version != '3.8' }}  # only add comments for one version
-          warnings: true
-
-      - name: Run pyright (Windows)
-        uses: jakebailey/pyright-action@v1.4.1
-        if: always() && (steps.pyright-linux.outcome == 'success' || steps.pyright-linux.outcome == 'failure')
-        with:
-          version: ${{ env.PYRIGHT_VERSION }}
-          python-version: ${{ steps.setup-env.outputs.python-version }}
-          python-platform: "Windows"
-          no-comments: true  # only add comments for one platform (see above)
-          warnings: true
+        run: uv run pytest tests/


### PR DESCRIPTION
- Replace flake8/pre-commit/pyright with ruff check + format
- Replace pip with uv
- Update actions to latest versions
- Test matrix: 3.11, 3.12, 3.13
- Drop Python 3.8-3.10 (requires-python >=3.11)